### PR TITLE
Fix a lab5 docs code bug

### DIFF
--- a/lab5/lab5_3_4_syscall.md
+++ b/lab5/lab5_3_4_syscall.md
@@ -17,7 +17,7 @@ idt_init(void) {
     extern uintptr_t __vectors[];
     int i;
     for (i = 0; i < sizeof(idt) / sizeof(struct gatedesc); i ++) {
-        SETGATE(idt[i], 1, GD_KTEXT, __vectors[i], DPL_KERNEL);
+        SETGATE(idt[i], 0, GD_KTEXT, __vectors[i], DPL_KERNEL);
     }
     SETGATE(idt[T_SYSCALL], 1, GD_KTEXT, __vectors[T_SYSCALL], DPL_USER);
     lidt(&idt_pd);


### PR DESCRIPTION
这里内核态明显要设置istrap = 0才对吧（而且代码里也是这么做的，目测是文档错了）