### PR TITLE
use minus to specify options rather than dash

### DIFF
--- a/lab0/lab0_2_4_1_2_2_configure_make_install_qemu.md
+++ b/lab0/lab0_2_4_1_2_2_configure_make_install_qemu.md
@@ -19,5 +19,5 @@ qemu执行程序将缺省安装到 /usr/local/bin 目录下。
  
 建立符号链接文件qemu
 
-	sudo ln –s /usr/local/bin/qemu-system-i386  /usr/local/bin/qemu
+	sudo ln -s /usr/local/bin/qemu-system-i386  /usr/local/bin/qemu
  


### PR DESCRIPTION
Your dash character (–) is different from the minus character (-) used to specify options.